### PR TITLE
Added missing gulp-jade in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.5",
     "jshint-stylish": "^2.0.0",
-    "gulp-plumber": "^1.0.1"
+    "gulp-plumber": "^1.0.1",
+    "gulp-jade": "^1.1.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Cloned the project, and ran it for the first time - noticed the gulp-jade dependency was missing from package.json